### PR TITLE
Drop .js extension to play nice with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-toast",
   "version": "1.4.4",
   "description": "A NativeScript Toast Plugin for Android and iOS apps.",
-  "main": "toast.js",
+  "main": "toast",
   "typings": "index.d.ts",
   "scripts": {
     "clean": "git checkout samples/angular/package.json && rm -rf node_modules target tmp && mkdir -p tmp && mkdir -p tmp/angular && cd samples/angular && rm -rf node_modules hooks platforms",


### PR DESCRIPTION
Webpack fails to find this plugin because of the `.js` extension in `main` file from package.json (it is actually looking for a file named `toast.js.android.js`).

As per http://docs.nativescript.org/tooling/bundling-with-webpack#recommendations-for-plugin-authors I have removed the extension.